### PR TITLE
BLOG-58, add eslint extends

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["prettier"],
+    "extends": ["prettier", "plugin:@next/next/recommended"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "yarn": "^1.22.19"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^13.4.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/js-cookie": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,13 @@
   dependencies:
     glob "7.1.7"
 
+"@next/eslint-plugin-next@^13.4.3":
+  version "13.4.3"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.3.tgz#9f3b9dedc8da57436e45d736f5fc6646e93a2656"
+  integrity sha512-5B0uOnh7wyUY9vNNdIA6NUvWozhrZaTMZOzdirYAefqD0ZBK5C/h3+KMYdCKrR7JrXGvVpWnHtv54b3dCzwICA==
+  dependencies:
+    glob "7.1.7"
+
 "@next/swc-darwin-arm64@13.3.2":
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.2.tgz#4def23ae8e162722140598bc8846013073d15285"


### PR DESCRIPTION
## eslint extends추가
```
"extends": ["prettier", "plugin:@next/next/recommended"],
```

##  @next/eslint-plugin-next 설치

## Reference
https://nextjs.org/docs/pages/building-your-application/configuring/eslint#migrating-existing-config