### PR TITLE
BLOG-75 fix: 화면비율이 작아졌을때 레이아웃이 깨지는 이슈 수정

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,26 +1,33 @@
-import { normalRowStyles } from '@/styles/flexModules';
+import { centerRowStyles, normalRowStyles } from '@/styles/flexModules';
 import styled from '@emotion/styled';
 
 export default function Footer() {
     return (
         <StyledFooter>
-            <p>소재지 : 방구석</p>
-            <p>작업자 : 우진택 문혜민 조준영</p>
+            <div>
+                <p>소재지 : 방구석</p>
+                <p>작업자 : 우진택 문혜민 조준영</p>
+            </div>
         </StyledFooter>
     );
 }
 const StyledFooter = styled.div`
-    ${normalRowStyles}
-    justify-content: end;
+    ${centerRowStyles}
     height: 50px;
-    padding: 0 50px;
     font-size: 12px;
     min-width: 1200px;
-    width: 90%;
-    > p {
-        &:first-of-type {
-            margin: 0 30px 0 0;
+
+    > div {
+        width: 1280px;
+        ${normalRowStyles}
+        justify-content: end;
+
+        padding: 20px 0 0;
+        > p {
+            &:first-of-type {
+                margin: 0 30px 0 0;
+            }
+            color: ${(props) => props.theme.colors.txt_gray};
         }
-        color: ${(props) => props.theme.colors.txt_gray};
     }
 `;

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -45,11 +45,12 @@ const StyledHeader = styled.div`
     background-color: white;
     border-bottom: 1px solid ${(props) => props.theme.colors.line_default};
     height: 80px;
+    min-width: 1280px;
+    width: 100%;
 
     > div {
         ${spaceBetweenRowStyles}
-        min-width: 1200px;
-        width: 90%;
+        width: 1200px;
         height: 100%;
         > p {
             color: ${(props) => props.theme.colors.point_yellow_green2};

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -21,6 +21,7 @@ export default function Layout(props: { children: ReactNode }) {
 
 const StyledLayout = styled.div`
     width: 100vw;
+    min-width: 1320px;
 `;
 const Body = styled.div`
     ${centerRowStyles}

--- a/src/layout/TopNavigation.tsx
+++ b/src/layout/TopNavigation.tsx
@@ -37,10 +37,11 @@ const StyledTopNavigation = styled.nav`
     background-color: white;
     height: 40px;
     border-bottom: 1px solid ${(props) => props.theme.colors.line_default};
-
+    min-width: 1280px;
+    width: 100%;
     > ul {
         ${normalRowStyles};
-        width: 90%;
+        width: 1280px;
         height: 100%;
         padding: 0 3rem;
     }


### PR DESCRIPTION
### 변경사항
- 화면 축소시. 레이아웃이 이상하게 뒤틀리는게 보여서 수정했습니다.
- 어드민 페이지는 데스크탑에서만 사용되도록 만들기로 했어서, 1280px 기준으로 생성했습니다.